### PR TITLE
feat: support mock prop with getter setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ const muk = require('muk-prop');
 
 const obj = { _a: 1 };
 muk(obj, 'a', {
-  set: function(val) { this._a = val; },
+  set: function(val) { this._a = val * 2; },
   get: function(val) { return this._a; },
 });
 
 obj.a = 2;
-// now we try to get obj._a
-console.log(obj._a); // 2
+console.log(obj.a); // 4
 ```
 
 Check if member has been mocked.

--- a/README.md
+++ b/README.md
@@ -27,24 +27,18 @@ const muk = require('muk-prop');
 // original obj with a getter/setter prop
 const obj = {
   _a: 1,
-  get a() {
-    return this._a;
-  },
-  set a(val) {
-    this._a = val;
-  },
 };
 
-// we mock it with new setter
+// we mock property 'a' with a setter
 muk(obj, a, {
-  set: function(val) {
-    this._a = val + 1;
+  set: function (val) {
+    this._a = val;
   },
 });
 
-obj.a = 1;
-// now we try to get obj.a
-console.log(obj.a); // 2
+obj.a = 2;
+// now we try to get obj._a
+console.log(obj._a); // 2
 ```
 
 Object props mocking with getter.
@@ -52,22 +46,20 @@ Object props mocking with getter.
 ```js
 const muk = require('muk-prop');
 
-// original obj with a getter/setter prop
+// original obj
 const obj = {
   _a: 1,
-  get a() {
-    return this._a;
-  },
 };
 
 muk(obj, a, {
-  get: () => {
-    throw new Error('oh no');
+  get: function () {
+    // got property a
+    return this._a + 1; 
   },
 });
 
 // now we try to get obj.a
-const res = obj.a; // will throw a Error
+const res = obj.a; // 2
 ```
 
 Check if member has been mocked.

--- a/README.md
+++ b/README.md
@@ -19,47 +19,20 @@ muk(fs, 'readFile', (path, callback) => {
 });
 ```
 
-Object props mocking with setter.
+Object props mocking with setter/getter.
 
 ```js
 const muk = require('muk-prop');
 
-// original obj with a getter/setter prop
-const obj = {
-  _a: 1,
-};
-
-// we mock property 'a' with a setter
-muk(obj, a, {
-  set: function (val) {
-    this._a = val;
-  },
+const obj = { _a: 1 };
+muk(obj, 'a', {
+  set: function(val) { this._a = val; },
+  get: function(val) { return this._a; },
 });
 
 obj.a = 2;
 // now we try to get obj._a
 console.log(obj._a); // 2
-```
-
-Object props mocking with getter.
-
-```js
-const muk = require('muk-prop');
-
-// original obj
-const obj = {
-  _a: 1,
-};
-
-muk(obj, a, {
-  get: function () {
-    // got property a
-    return this._a + 1; 
-  },
-});
-
-// now we try to get obj.a
-const res = obj.a; // 2
 ```
 
 Check if member has been mocked.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,64 @@ muk(fs, 'readFile', (path, callback) => {
 });
 ```
 
+Object props mocking with setter.
+
+```js
+const muk = require('muk-prop');
+
+// original obj with a getter/setter prop
+const obj = {
+  _a: 1,
+  get a() {
+    return this._a;
+  },
+  set a(val) {
+    this._a = val;
+  },
+};
+
+// we mock it with new setter
+muk(obj, a, {
+  set: function(val) {
+    this._a = val + 1;
+  },
+});
+
+obj.a = 1;
+// now we try to get obj.a
+console.log(obj.a); // 2
+```
+
+Object props mocking with getter.
+
+```js
+const muk = require('muk-prop');
+
+// original obj with a getter/setter prop
+const obj = {
+  _a: 1,
+  get a() {
+    return this._a;
+  },
+};
+
+muk(obj, a, {
+  get: () => {
+    throw new Error('oh no');
+  },
+});
+
+// now we try to get obj.a
+const res = obj.a; // will throw a Error
+```
+
 Check if member has been mocked.
 
 ```js
 muk.isMocked(fs, 'readFile'); // true
 ```
 
-Restore all mocked methods after tests.
+Restore all mocked methods/props after tests.
 
 ```js
 muk.restore();

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,6 @@ var cache = new Map();
  * @param {!Function|Object} value
  */
 var method = module.exports = (obj, key, value) => {
-  var noop = () => {};
-  value = value === undefined ? noop : value;
   var hasOwnProperty = obj.hasOwnProperty(key);
   mocks.push({
     obj,
@@ -42,10 +40,12 @@ var method = module.exports = (obj, key, value) => {
     enumerable: true,
   };
   
-  if (value.get || value.set) {
-    descriptor.get = value.get || noop;
-    descriptor.set = value.set || noop;
+  if (value && (value.get || value.set)) {
+    // Default to undefined
+    descriptor.get = value.get;
+    descriptor.set = value.set;
   } else {
+    // Without getter/setter mode
     descriptor.value = value;
     descriptor.writable = true;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,11 @@ var cache = new Map();
  * @param {Object} obj
  * @param {string} key
  * @param {!Function} method
+ * @param {!Function} extend -  { get(), set() }
  */
-var method = module.exports = (obj, key, method) => {
-  method = method === undefined ? () => {} : method;
+var method = module.exports = (obj, key, method, extend= {}) => {
+  var noop = () => {};
+  method = method === undefined ? noop : method;
   var hasOwnProperty = obj.hasOwnProperty(key);
   mocks.push({
     obj,
@@ -36,13 +38,22 @@ var method = module.exports = (obj, key, method) => {
   }
   flag.add(key);
 
-  Object.defineProperty(obj, key, {
-    writable: true,
-    configurable: true,
-    enumerable: true,
-    value: method
-  });
-
+  if (!method) {
+    // method->null use extend
+    Object.defineProperty(obj, key, {
+      configurable: true,
+      enumerable: true,
+      get: extend.getter || noop,
+      set: extend.setter || noop,
+    });
+  } else {
+    Object.defineProperty(obj, key, {
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      value: method,
+    });
+  }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,10 @@ var method = module.exports = (obj, key, value) => {
   var noop = () => {};
   value = value === undefined ? noop : value;
   var hasOwnProperty = obj.hasOwnProperty(key);
-  var descriptor = Object.getOwnPropertyDescriptor(obj, key);
   mocks.push({
     obj,
     key,
-    descriptor,
+    descriptor: Object.getOwnPropertyDescriptor(obj, key),
     // Make sure the key exists on object not the prototype
     hasOwnProperty,
   });
@@ -43,10 +42,10 @@ var method = module.exports = (obj, key, value) => {
     enumerable: true,
   };
   
-  if(value.get || value.set){
+  if (value.get || value.set) {
     descriptor.get = value.get || noop;
     descriptor.set = value.set || noop;
-  }else{
+  } else {
     descriptor.value = value;
     descriptor.writable = true;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,21 +6,21 @@ var cache = new Map();
 
 
 /**
- * Mocks a method of an object.
+ * Mocks a value of an object.
  *
  * @param {Object} obj
  * @param {string} key
- * @param {!Function} method
- * @param {!Function} extend -  { getter(), setter() }
+ * @param {!Function|Object} value
  */
-var method = module.exports = (obj, key, method, extend) => {
+var method = module.exports = (obj, key, value) => {
   var noop = () => {};
-  method = method === undefined ? noop : method;
+  value = value === undefined ? noop : value;
   var hasOwnProperty = obj.hasOwnProperty(key);
+  var descriptor = Object.getOwnPropertyDescriptor(obj, key);
   mocks.push({
     obj,
     key,
-    descriptor: Object.getOwnPropertyDescriptor(obj, key),
+    descriptor,
     // Make sure the key exists on object not the prototype
     hasOwnProperty,
   });
@@ -38,22 +38,20 @@ var method = module.exports = (obj, key, method, extend) => {
   }
   flag.add(key);
 
-  if (!method && extend) {
-    // method->null use extend
-    Object.defineProperty(obj, key, {
-      configurable: true,
-      enumerable: true,
-      get: extend.getter || noop,
-      set: extend.setter || noop,
-    });
-  } else {
-    Object.defineProperty(obj, key, {
-      writable: true,
-      configurable: true,
-      enumerable: true,
-      value: method,
-    });
+  var descriptor = {
+    configurable: true,
+    enumerable: true,
+  };
+  
+  if(value.get || value.set){
+    descriptor.get = value.get || noop;
+    descriptor.set = value.set || noop;
+  }else{
+    descriptor.value = value;
+    descriptor.writable = true;
   }
+
+  Object.defineProperty(obj, key, descriptor);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,9 @@ var cache = new Map();
  * @param {Object} obj
  * @param {string} key
  * @param {!Function} method
- * @param {!Function} extend -  { get(), set() }
+ * @param {!Function} extend -  { getter(), setter() }
  */
-var method = module.exports = (obj, key, method, extend= {}) => {
+var method = module.exports = (obj, key, method, extend) => {
   var noop = () => {};
   method = method === undefined ? noop : method;
   var hasOwnProperty = obj.hasOwnProperty(key);
@@ -38,7 +38,7 @@ var method = module.exports = (obj, key, method, extend= {}) => {
   }
   flag.add(key);
 
-  if (!method) {
+  if (!method && extend) {
     // method->null use extend
     Object.defineProperty(obj, key, {
       configurable: true,

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -190,7 +190,7 @@ describe('Mock value with getter', () => {
 
     try {
       obj.a;
-    } catch(e) {
+    } catch (e) {
       assert.equal(e.message, 'oh no')
     }
   });
@@ -225,7 +225,7 @@ describe('Mock value with setter', () => {
   it('Value are new setter after mocked', () => {
     muk(obj, 'a', {
       set: function(value) {
-        this._a = value +1;
+        this._a = value + 1;
       },
       get: function() {
         return this._a;
@@ -244,7 +244,7 @@ describe('Mock value with setter', () => {
 
     try {
       obj.a = 2;
-    } catch(e) {
+    } catch (e) {
       assert.equal(e.message, 'oh no')
     }
   });
@@ -252,7 +252,7 @@ describe('Mock value with setter', () => {
   it('Should have original setter after muk.restore()', () => {
     muk(obj, 'a', {
       set: function(value) {
-        this._a = value +1;
+        this._a = value + 1;
       },
     });
     

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -174,45 +174,91 @@ describe('Mock value with getter', () => {
 
   afterEach(muk.restore);
   
-  it('Should have original getter after muk.restore()', () => {
-    muk(obj, 'a', null, {
-      getter: () => {
-        return 2;
-      }
+  it('Value are new getter after mocked', () => {
+    muk(obj, 'a', {
+      get: () => 2,
     });
     assert.equal(obj.a, 2, 'property a of obj is 2 with getter');
   });
   
   it('Should throw error when getter', () => {
-    muk(obj, 'a', null, {
-      getter: () => {
+    muk(obj, 'a', {
+      get: () => {
         throw new Error('oh no');
       }
     });
 
-    try{
+    try {
       obj.a;
-    }catch(e){
+    } catch(e) {
       assert.equal(e.message, 'oh no')
     }
   });
   
   it('Should have original getter after muk.restore()', () => {
-    muk(obj, 'a', null, {
-      
-    });
-    assert.equal(obj.a, undefined, 'property a of obj is undefined with empty getter');
-  });
-  
-  it('Should have original getter after muk.restore()', () => {
-    muk(obj, 'a', null, {
-      getter: () => {
-        return 2;
-      }
+    muk(obj, 'a', {
+      get: () => 2,
     });
     
     muk.restore();
-    assert.equal(obj.a, 1, 'property a of obj is equal to origin');
+    assert.equal(obj.a, 1, 'property a of obj is equal to original');
+  });
+});
+
+describe('Mock value with setter', () => {
+  var obj = {
+    _a: 1,
+  };
+
+  Object.defineProperty(obj, 'a', {
+    configurable: true,
+    set: function(value) {
+      this._a = value;
+    },
+    get: function() {
+      return this._a;
+    },
+  })
+
+  afterEach(muk.restore);
+  
+  it('Value are new setter after mocked', () => {
+    muk(obj, 'a', {
+      set: function(value) {
+        this._a = value +1;
+      },
+      get: function() {
+        return this._a;
+      },
+    });
+    obj.a = 2;
+    assert.equal(obj.a, 3, 'property a of obj is 3 with getter');
+  });
+  
+  it('Should throw error when setter', () => {
+    muk(obj, 'a', {
+      set: () => {
+        throw new Error('oh no');
+      }
+    });
+
+    try {
+      obj.a = 2;
+    } catch(e) {
+      assert.equal(e.message, 'oh no')
+    }
+  });
+  
+  it('Should have original setter after muk.restore()', () => {
+    muk(obj, 'a', {
+      set: function(value) {
+        this._a = value +1;
+      },
+    });
+    
+    muk.restore();
+    obj.a = 2;
+    assert.equal(obj.a, 2, 'property a of obj is equal to original');
   });
 });
 

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -167,6 +167,41 @@ describe('Mock getter', () => {
   });
 });
 
+describe('Mock value with getter', () => {
+  var obj = {
+    a: 1,
+  };
+
+  afterEach(muk.restore);
+  
+  it('Should have original getter after muk.restore()', () => {
+    muk(obj, 'a', null, {
+      getter: () => {
+        return 2;
+      }
+    });
+    assert.equal(obj.a, 2, 'property a of obj is 2 with getter');
+  });
+  
+  it('Should have original getter after muk.restore()', () => {
+    muk(obj, 'a', null, {
+      
+    });
+    assert.equal(obj.a, undefined, 'property a of obj is undefined with empty getter');
+  });
+  
+  it('Should have original getter after muk.restore()', () => {
+    muk(obj, 'a', null, {
+      getter: () => {
+        return 2;
+      }
+    });
+    
+    muk.restore();
+    assert.equal(obj.a, 1, 'property a of obj is equal to origin');
+  });
+});
+
 describe('Mock check', () => {
 
   afterEach(muk.restore);

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -115,10 +115,9 @@ describe('Mock property', () => {
     assert(!hasOwnProperty(process.env, 'notExistProp'), 'notExistProp is deleted');
   });
 
-  it('should mock function when method is null', () => {
+  it('should be undefined when value is not set', () => {
     muk(config, 'enableCache');
-    assert.equal(typeof config.enableCache, 'function', 'enableCache is function');
-    assert.equal(config.enableCache(), undefined, 'enableCache return undefined');
+    assert.equal(config.enableCache, undefined, 'enableCache is undefined');
   });
 
   it('should mock property on prototype', () => {

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -197,7 +197,7 @@ describe('Mock value with getter', () => {
     }
   });
   
-  it('Should throw error getter ', () => {
+  it('Should have original getter after muk.restore()', () => {
     muk(obj, 'a', null, {
       
     });

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -183,7 +183,21 @@ describe('Mock value with getter', () => {
     assert.equal(obj.a, 2, 'property a of obj is 2 with getter');
   });
   
-  it('Should have original getter after muk.restore()', () => {
+  it('Should throw error when getter', () => {
+    muk(obj, 'a', null, {
+      getter: () => {
+        throw new Error('oh no');
+      }
+    });
+
+    try{
+      obj.a;
+    }catch(e){
+      assert.equal(e.message, 'oh no')
+    }
+  });
+  
+  it('Should throw error getter ', () => {
     muk(obj, 'a', null, {
       
     });


### PR DESCRIPTION
> 支持 mock 对象属性时，使用 getter/setter 模式

```js
muk({}, 'key', null , {
   getter: function(){
   
   },
  setter: function() {

  } 
});
```