### PR TITLE
fix: change mock getter/setter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ Object props mocking with setter/getter.
 const muk = require('muk-prop');
 
 const obj = { _a: 1 };
-muk(obj, 'a', {
-  set: (val) => obj._a = val * 2,
-  get: (val) => obj._a,
+const mockObj = {};
+Object.defineProperty(mockObj, 'a', {
+  set: (val) => obj._a = val * 2,,
+  get: () => obj._a, 
 });
+muk(obj, 'a', mockObj.a);
 
 obj.a = 2;
 console.log(obj.a); // 4

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,18 +40,24 @@ const method = module.exports = (obj, key, value) => {
     configurable: true,
     enumerable: true,
   };
-
-  // Map.prototype.get/set are not valid getter/setter
-  const hasGetter = value && hasOwn.call(value, 'get');
-  const hasSetter = value && hasOwn.call(value, 'set');
-  if (hasGetter || hasSetter) {
-    // Default to undefined
-    descriptor.get = value.get;
-    descriptor.set = value.set;
-  } else {
-    // Without getter/setter mode
+  if (!value || typeof value !== 'object') {
     descriptor.value = value;
     descriptor.writable = true;
+  } else {
+    // Object.get or Map.prototype.get/set are not valid getter/setter
+    const ownPropertyDescriptor = Object.getOwnPropertyDescriptor(value, key);
+    const hasGetter = ownPropertyDescriptor && typeof ownPropertyDescriptor.get === 'function';
+    const hasSetter = ownPropertyDescriptor && typeof ownPropertyDescriptor.set === 'function';
+    if (hasGetter || hasSetter) {
+      // Default to undefined
+      descriptor.get = ownPropertyDescriptor.get;
+      descriptor.set = ownPropertyDescriptor.set;
+    } else {
+      // Without getter/setter mode
+      // e.g. { get: () => 1 }
+      descriptor.value = value;
+      descriptor.writable = true;
+    }
   }
 
   Object.defineProperty(obj, key, descriptor);

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -197,7 +197,9 @@ describe('Mock value with getter', () => {
     muk(obj, 'a', {
       get: () => 2,
     });
-    assert.equal(obj.a, 2, 'property a of obj is 2 with getter');
+
+    assert.equal(typeof obj.a.get, 'function', 'property a.get of obj is a function');
+    assert.equal(obj.a.get(), 2, 'property a of obj is 2 with getter');
   });
 
   it('Should throw error when getter', () => {
@@ -208,7 +210,7 @@ describe('Mock value with getter', () => {
     });
 
     try {
-      obj.a;
+      obj.a.get();
     } catch (e) {
       assert.equal(e.message, 'oh no');
     }
@@ -237,21 +239,14 @@ describe('Mock value with setter', () => {
 
   afterEach(muk.restore);
 
-  it('Value are new setter after mocked', () => {
-    muk(obj, 'a', {
-      set: (value) => obj._a = value + 1,
-      get: () => obj._a,
-    });
-    obj.a = 2;
-    assert.equal(obj.a, 3, 'property a of obj is 3 with getter');
-  });
-
   it('Should throw error when setter', () => {
-    muk(obj, 'a', {
+    const mockObj = {};
+    Object.defineProperty(mockObj, 'a', {
       set: () => {
         throw Error('oh no');
-      }
+      },
     });
+    muk(obj, 'a', mockObj.a);
 
     try {
       obj.a = 2;


### PR DESCRIPTION
The original getter/setter mock API is conflicted with the `Object` behavior. This PR provides a more comprehensive API.
```javascript
// given an example below
const obj = { a: 1 };
muk(obj, 'a', {
  get: () => 2,
});

// old behavior
// the `get` function resets the getter of `obj.a`
console.log(obj.a); // 2

// new behavior
// the `get` function, along with the mock `Object` data, resets the value of `obj.a`
console.log(ob.a); // { get: {} => 2 }
console.log(obj.a.get()); // 2
```

